### PR TITLE
Added code to evaluate background

### DIFF
--- a/runs_spherical_shock/Makefile.am
+++ b/runs_spherical_shock/Makefile.am
@@ -3,7 +3,8 @@
 AM_CXXFLAGS = $(MPI_CFLAGS)
 AM_LDFLAGS = $(MPI_LIBS)
 
-bin_PROGRAMS = dsa_forward dsa_backward dsa_forward_postprocess dsa_backward_postprocess dsa_analytic
+bin_PROGRAMS = dsa_forward dsa_backward dsa_forward_postprocess dsa_backward_postprocess dsa_analytic \
+               dsa_plot_background
 
 SPBL_COMMON_DIR = ../common
 SPBL_SOURCE_DIR = ../src
@@ -192,3 +193,42 @@ dsa_analytic_SOURCES = dsa_analytic.cc dsa_common.hh \
    $(SPBL_COMMON_DIR)/print_warn.hh
 
 dsa_analytic_LDADD = $(MPI_LIBS) $(GSL_LIBS)
+
+dsa_plot_background_SOURCES = dsa_plot_background.cc \
+   $(SPBL_SOURCE_DIR)/background_solarwind_termshock.cc \
+   $(SPBL_SOURCE_DIR)/background_solarwind_termshock.hh \
+   $(SPBL_SOURCE_DIR)/background_solarwind.cc \
+   $(SPBL_SOURCE_DIR)/background_solarwind.hh \
+   $(SPBL_SOURCE_DIR)/background_base.cc \
+   $(SPBL_SOURCE_DIR)/background_base_visual.cc \
+   $(SPBL_SOURCE_DIR)/background_base.hh \
+   $(SPBL_SOURCE_DIR)/diffusion_base.cc \
+   $(SPBL_SOURCE_DIR)/diffusion_base.hh \
+   $(SPBL_SOURCE_DIR)/server_base.cc \
+   $(SPBL_SOURCE_DIR)/server_base.hh \
+   $(SPBL_SOURCE_DIR)/block_base.cc \
+   $(SPBL_SOURCE_DIR)/block_base.hh \
+   $(SPBL_SOURCE_DIR)/cache_lru.cc \
+   $(SPBL_SOURCE_DIR)/cache_lru.hh \
+   $(SPBL_COMMON_DIR)/mpi_config.cc \
+   $(SPBL_COMMON_DIR)/mpi_config.hh \
+   $(SPBL_COMMON_DIR)/data_container.hh \
+   $(SPBL_COMMON_DIR)/data_container.cc \
+   $(SPBL_COMMON_DIR)/matrix.cc \
+   $(SPBL_COMMON_DIR)/matrix.hh \
+   $(SPBL_COMMON_DIR)/vectors.cc \
+   $(SPBL_COMMON_DIR)/vectors.hh \
+   $(SPBL_COMMON_DIR)/params.cc \
+   $(SPBL_COMMON_DIR)/params.hh \
+   $(SPBL_COMMON_DIR)/physics.cc \
+   $(SPBL_COMMON_DIR)/physics.hh \
+   $(SPBL_COMMON_DIR)/random.hh \
+   $(SPBL_COMMON_DIR)/spatial_data.hh \
+   $(SPBL_COMMON_DIR)/rk_config.hh \
+   $(SPBL_COMMON_DIR)/multi_index.hh \
+   $(SPBL_COMMON_DIR)/simple_array.hh \
+   $(SPBL_COMMON_DIR)/arithmetic.hh \
+   $(SPBL_COMMON_DIR)/definitions.hh \
+   $(SPBL_COMMON_DIR)/print_warn.hh
+
+dsa_plot_background_LDADD = $(MPI_LIBS) $(GSL_LIBS)

--- a/runs_spherical_shock/dsa_plot_background.cc
+++ b/runs_spherical_shock/dsa_plot_background.cc
@@ -1,0 +1,95 @@
+#include "src/server_config.hh"
+#include "src/background_solarwind_termshock.hh"
+#include "dsa_common.hh"
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <filesystem>
+
+using namespace Spectrum;
+
+int main(int argc, char** argv)
+{
+   int i;
+   BackgroundSolarWindTermShock background;
+   std::ofstream plot_file;
+   SpatialData spdata;
+   DataContainer container;
+   GeoVector pos, mom;
+
+   ReadParams();
+   DefineArrays();
+   spdata._mask = BACKGROUND_U | BACKGROUND_B | BACKGROUND_gradU;
+
+   container.Clear();
+
+// Initial time
+   container.Insert(0.0);
+
+// Origin
+   container.Insert(gv_zeros);
+
+// Upstream velocity
+   GeoVector u0(U_up, 0.0, 0.0);
+   container.Insert(u0);
+
+// Upstream magnetic field
+   double RS = 6.957e10 / unit_length_fluid;
+   double r_ref = 3.0 * RS;
+   double BmagE = 5.0e-5 / unit_magnetic_fluid;
+   double Bmag_ref = BmagE * Sqr(one_au / r_ref);
+   GeoVector B0(Bmag_ref, 0.0, 0.0);
+   container.Insert(B0);
+
+// Maximum displacement
+   container.Insert(dmax);
+
+// Solar rotation vector
+   GeoVector Omega(0.0, 0.0, 0.0);
+   container.Insert(Omega);
+
+// Reference equatorial distance
+   container.Insert(r_ref);
+
+// dmax fraction
+   container.Insert(dmax_fraction);
+
+// Spherical shock radius
+   container.Insert(R_sh); 
+
+// Spherical shock width
+   container.Insert(w_sh);
+   
+// Spherical shock strength
+   container.Insert(s);
+
+   background.SetupObject(container);
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------
+
+// Parameters for plotting
+   int pts = Nr;
+   if(argc > 1) pts = atoi(argv[1]);
+   double dr_plot = (rf - r0) / (pts-1);
+   pos[0] = r0;
+   pos[1] = 0.0;
+   pos[2] = 0.0;
+   mom[0] = p_inj;
+
+// Plot
+   plot_file.open("dsa_results/solarwind.dat");
+   for (i = 0; i < pts; i++) {
+      background.GetFields(0.0, pos, mom, spdata);
+      plot_file << std::setw(18) << pos[0]
+                << std::setw(18) << spdata.Uvec.Norm() * unit_velocity_fluid
+                << std::setw(18) << spdata.Bmag * unit_magnetic_fluid
+                << std::setw(18) << spdata.divU() * unit_velocity_fluid / unit_length_fluid
+                << std::endl;
+      pos[0] += dr_plot;
+   };
+   plot_file.close();
+
+   return 0;
+};
+
+

--- a/src/background_solarwind.cc
+++ b/src/background_solarwind.cc
@@ -253,6 +253,7 @@ void BackgroundSolarWind::EvaluateBackgroundDerivatives(void)
    };
    if (BITS_RAISED(_spdata._mask, BACKGROUND_gradB)) {
 //TODO: complete
+      _spdata.gradBvec = gm_zeros;
    };
    if (BITS_RAISED(_spdata._mask, BACKGROUND_gradE)) {
       _spdata.gradEvec = -((_spdata.gradUvec ^ _spdata.Bvec) + (_spdata.Uvec ^ _spdata.gradBvec)) / c_code;

--- a/src/background_solarwind.hh
+++ b/src/background_solarwind.hh
@@ -15,7 +15,7 @@ This file is part of the SPECTRUM suite of scientific numerical simulation codes
 namespace Spectrum {
 
 //! Method for computing derivatives (0: analytical, 1: numerical)
-#define SOLARWIND_DERIVATIVE_METHOD 1
+#define SOLARWIND_DERIVATIVE_METHOD 0
 
 //! Heliospheric current sheet (0: disabled, 1: flat, 2: wavy (Jokipii-Thomas 1981) and static, 3: wavy and time-dependent).
 #define SOLARWIND_CURRENT_SHEET 0

--- a/src/background_solarwind_termshock.cc
+++ b/src/background_solarwind_termshock.cc
@@ -199,6 +199,7 @@ void BackgroundSolarWindTermShock::EvaluateBackgroundDerivatives(void)
    };
    if (BITS_RAISED(_spdata._mask, BACKGROUND_gradB)) {
 //TODO: complete
+      _spdata.gradBvec = gm_zeros;
    };
    if (BITS_RAISED(_spdata._mask, BACKGROUND_gradE)) {
       _spdata.gradEvec = -((_spdata.gradUvec ^ _spdata.Bvec) + (_spdata.Uvec ^ _spdata.gradBvec)) / c_code;


### PR DESCRIPTION
A simple code to evaluate the background for the spehrical shock case was added. Also, the derivative compuation was changed from numerical to analytic in the spherical shock case. This neglects the magnetic field derivatives, but this is ok because they are not important for this application.