### PR TITLE
Corrected gradient computation

### DIFF
--- a/common/matrix.cc
+++ b/common/matrix.cc
@@ -87,6 +87,16 @@ SPECTRUM_DEVICE_FUNC void GeoMatrix::ChangeToBasis(const GeoMatrix& basis)
 };
 
 /*!
+\author Juan G Alonso Guzman
+\date 07/24/2025
+\param[in] basis A matrix whose components are new basis vectors
+*/
+SPECTRUM_DEVICE_FUNC void GeoMatrix::ChangeToBasis(const GeoVector* basis)
+{
+// TODO
+};
+
+/*!
 \author Vladimir Florinski
 \date 08/31/2022
 \param[in] basis A matrix whose rows are new basis vectors
@@ -94,6 +104,20 @@ SPECTRUM_DEVICE_FUNC void GeoMatrix::ChangeToBasis(const GeoMatrix& basis)
 SPECTRUM_DEVICE_FUNC void GeoMatrix::ChangeFromBasis(const GeoMatrix& basis)
 {
    for (auto uvw = 0; uvw < 3; uvw++) row[uvw].ChangeFromBasis(basis.VectorArray());
+};
+
+/*!
+\author Juan G Alonso Guzman
+\date 07/24/2025
+\param[in] basis A matrix whose components are new basis vectors
+*/
+SPECTRUM_DEVICE_FUNC void GeoMatrix::ChangeFromBasis(const GeoVector* basis)
+{
+   GeoMatrix mat_tmp;
+   memcpy(mat_tmp.linear, linear, 9 * SZDBL);
+   for (auto xyz = 0; xyz < 3; xyz++) {
+      for (auto uvw = 0; uvw < 3; uvw++) row[xyz][uvw] = basis[xyz] * mat_tmp * basis[uvw];
+   }
 };
 
 /*!

--- a/common/matrix.hh
+++ b/common/matrix.hh
@@ -101,11 +101,17 @@ struct GeoMatrix {
 //! Generate a basis with the z-axis along the given direction
    SPECTRUM_DEVICE_FUNC void AxisymmetricBasis(const GeoVector& ez);
 
-//! Convert components from the standard basis to a different basis
+//! Convert rows from the standard basis to a different basis
    SPECTRUM_DEVICE_FUNC void ChangeToBasis(const GeoMatrix& basis);
 
-//! Convert components to the standard basis from a different basis
+//! Convert components from the standard basis to a different basis
+   SPECTRUM_DEVICE_FUNC void ChangeToBasis(const GeoVector* basis);
+
+//! Convert rows to the standard basis from a different basis
    SPECTRUM_DEVICE_FUNC void ChangeFromBasis(const GeoMatrix& basis);
+
+//! Convert components to the standard basis from a different basis
+   SPECTRUM_DEVICE_FUNC void ChangeFromBasis(const GeoVector* basis);
 
 //! Compute a minor
    SPECTRUM_DEVICE_FUNC double Minor(int i, int j) const;

--- a/src/background_solarwind.cc
+++ b/src/background_solarwind.cc
@@ -268,6 +268,7 @@ void BackgroundSolarWind::EvaluateBackgroundDerivatives(void)
       _spdata.gradUvec[2][2] = _spdata.Uvec.Norm() / r;
 // Convert to Cartesian
       _spdata.gradUvec = SphericalToCartesian * _spdata.gradUvec * CartesianToSpherical;
+      _spdata.gradUvec.ChangeFromBasis(eprime);
    };
    if (BITS_RAISED(_spdata._mask, BACKGROUND_gradB)) {
 // Expressions valid only for radial field ~ 1/r^2
@@ -279,7 +280,9 @@ void BackgroundSolarWind::EvaluateBackgroundDerivatives(void)
       _spdata.gradBmag[0] = -2.0 * _spdata.Bvec.Norm() / r;
 // Convert to Cartesian
       _spdata.gradBvec = SphericalToCartesian * _spdata.gradBvec * CartesianToSpherical;
+      _spdata.gradBvec.ChangeFromBasis(eprime);
       _spdata.gradBmag = SphericalToCartesian * _spdata.gradBmag;
+      _spdata.gradBmag.ChangeFromBasis(eprime);
    };
    if (BITS_RAISED(_spdata._mask, BACKGROUND_gradE)) {
       _spdata.gradEvec = -((_spdata.gradUvec ^ _spdata.Bvec) + (_spdata.Uvec ^ _spdata.gradBvec)) / c_code;

--- a/src/background_solarwind_termshock.cc
+++ b/src/background_solarwind_termshock.cc
@@ -197,6 +197,7 @@ void BackgroundSolarWindTermShock::EvaluateBackgroundDerivatives(void)
       _spdata.gradUvec[2][2] = _spdata.Uvec.Norm() / r;
 // Convert to Cartesian
       _spdata.gradUvec = SphericalToCartesian * _spdata.gradUvec * CartesianToSpherical;
+      _spdata.gradUvec.ChangeFromBasis(eprime);
    };
    if (BITS_RAISED(_spdata._mask, BACKGROUND_gradB)) {
 // Expressions valid only for radial field ~ 1/r^2
@@ -208,7 +209,9 @@ void BackgroundSolarWindTermShock::EvaluateBackgroundDerivatives(void)
       _spdata.gradBmag[0] = -2.0 * _spdata.Bvec.Norm() / r;
 // Convert to Cartesian
       _spdata.gradBvec = SphericalToCartesian * _spdata.gradBvec * CartesianToSpherical;
+      _spdata.gradBvec.ChangeFromBasis(eprime);
       _spdata.gradBmag = SphericalToCartesian * _spdata.gradBmag;
+      _spdata.gradBmag.ChangeFromBasis(eprime);
    };
    if (BITS_RAISED(_spdata._mask, BACKGROUND_gradE)) {
       _spdata.gradEvec = -((_spdata.gradUvec ^ _spdata.Bvec) + (_spdata.Uvec ^ _spdata.gradBvec)) / c_code;


### PR DESCRIPTION
In the solar wind backgrounds, the use of an intermediate Cartesian basis (eprime) was ignored, so the results were incorrect. This has been fixed by adding a function to implement the correct ChangeFromBasis routine in the common GeoMatrix routines.